### PR TITLE
Remove Facebook from active social

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,16 +189,6 @@
                     </div>
                     <div class="4u 12u(mobile)">
                         <section class="box style1">
-                            <a href="https://www.facebook.com/PythonMilano">
-                                <span class="icon featured fa-facebook"></span>
-                                <h3>Facebook</h3>
-                            </a>
-                        </section>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="4u 12u(mobile)">
-                        <section class="box style1">
                             <a href="https://www.youtube.com/@pythonmilano">
                                 <span class="icon featured fa-youtube"></span>
                                 <h3>YouTube</h3>


### PR DESCRIPTION
The thing is. I closed my Facebook account so I don't have access to the page anymore. Since I was the only person updating it has not sense having this link in the website.
I think the page is still there, it was opened by "greekey" / Lorenzo if I remember well.